### PR TITLE
v2.15.1 feat: bump hx-ext-amz-content-sha256 and small patches to loc…

### DIFF
--- a/pkg/data/src/layouts/layout.templ
+++ b/pkg/data/src/layouts/layout.templ
@@ -24,7 +24,7 @@ templ PageLayout() {
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<link rel="stylesheet" href="/public/styles.css"/>
 			<script src="https://unpkg.com/htmx.org@2.0.3" integrity="sha384-0895/pl2MU10Hqc6jd4RvrthNlDiE9U1tWmX7WRESftEDRosgxNsQG/Ze9YMRzHq" crossorigin="anonymous"></script>
-			<script defer src="https://unpkg.com/hx-ext-amz-content-sha256@1.0.11/min.js"></script>
+			<script defer src="https://unpkg.com/hx-ext-amz-content-sha256@1.0.12/min.js"></script>
 		</head>
 		<body class="antialiased flex flex-col justify-center items-center w-screen h-screen bg-black p-3" hx-ext="amz-content-sha256">
 			{ children... }

--- a/pkg/helpers/routes/setup.go
+++ b/pkg/helpers/routes/setup.go
@@ -8,6 +8,13 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+func noCacheMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store, must-revalidate")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // Setup initializes caching, static file serving, and registers routes.
 // It reads the GOTHIC_MODE environment variable to determine dev vs production mode.
 // In dev mode (GOTHIC_MODE=dev), LocalDevelopmentCache is used; in production, CacheStrategy is used.
@@ -31,7 +38,12 @@ func Setup(router chi.Router, config AppConfig, registerRoutes func(chi.Router))
 
 	if config.ServeStaticFiles == ALL_ENVS || isDev {
 		slog.Info("application serving local public folder")
-		router.Handle("/public/*", http.StripPrefix("/public/", http.FileServer(http.Dir("./public/"))))
+		fileServer := http.StripPrefix("/public/", http.FileServer(http.Dir("./public/")))
+		if isDev {
+			router.Handle("/public/*", noCacheMiddleware(fileServer))
+		} else {
+			router.Handle("/public/*", fileServer)
+		}
 	}
 
 	router.Group(registerRoutes)


### PR DESCRIPTION
## What's Changed                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                       
  ### Bug Fixes
  - **Fix dev mode CSS caching** — Added `Cache-Control: no-store, must-revalidate` to all `/public/*` responses in dev mode (`GOTHIC_MODE=dev`). Prevents Chrome from serving stale CSS when switching between Gothic projects or during hot reload.
  Production behavior is unchanged.

  ### Dependencies
  - Bump `hx-ext-amz-content-sha256` from 1.0.11 to 1.0.12