### PR TITLE
hotfix: pin version current commit

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -77,7 +77,7 @@ func (command *InitCommand) CreateNewGothicApp(data cli_data.GothicCliData) erro
 	if _, err := command.cli.Tailwind.EnsureBinary(); err != nil {
 		return fmt.Errorf("error downloading tailwind binary: %w", err)
 	}
-	if err := command.cli.InitializeModule(command.gothicCliData.GoModName); err != nil {
+	if err := command.cli.InitializeModule(command.gothicCliData.GoModName, CURRENT_COMMIT); err != nil {
 		return err
 	}
 	if err := command.cli.Templ.Render(); err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CURRENT_VERSION string = "v2.16.1"
+var CURRENT_VERSION string = "v2.16.2"
+
+// CURRENT_COMMIT is the Go pseudo-version of the gothicframework module that
+// ships with this binary. Used by init to pin the exact version before go mod
+// tidy, so new projects don't resolve a stale proxy-cached version.
+// Update this alongside CURRENT_VERSION on every release using:
+//
+//	GOWORK=off go list -m github.com/felipegenef/gothicframework@<short-hash>
+var CURRENT_COMMIT string = "v0.0.0-20260525184758-edc8106ea11e"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -101,12 +101,22 @@ func (cli *GothicCli) GetConfig() (Config, error) {
 	return config, nil
 }
 
-func (cli *GothicCli) InitializeModule(goModuleName string) error {
+func (cli *GothicCli) InitializeModule(goModuleName string, frameworkVersion string) error {
 	initCmd := exec.Command("go", "mod", "init", goModuleName)
 	initCmd.Stdin = os.Stdin
 	initCmd.Stderr = os.Stderr
 	if err := initCmd.Run(); err != nil {
 		return fmt.Errorf("error running go mod init: %w", err)
+	}
+	// Pin the exact gothicframework pseudo-version before go mod tidy so the
+	// proxy cannot resolve a stale cached version instead.
+	if frameworkVersion != "" {
+		pinCmd := exec.Command("go", "get", "github.com/felipegenef/gothicframework@"+frameworkVersion)
+		pinCmd.Stdin = os.Stdin
+		pinCmd.Stderr = os.Stderr
+		if err := pinCmd.Run(); err != nil {
+			return fmt.Errorf("error pinning gothicframework version: %w", err)
+		}
 	}
 	tidyCmd := exec.Command("go", "mod", "tidy")
 	tidyCmd.Stdin = os.Stdin


### PR DESCRIPTION
# Patch Notes — v2.16.2

## Bug Fixes

### `gothicframework init` — pins gothicframework version to avoid stale proxy cache

`go mod tidy` in newly scaffolded projects was resolving a stale cached version of `gothicframework` from the Go module proxy instead of the version that ships with the installed binary. `gothicframework init` now runs `go get github.com/felipegenef/gothicframework@<pseudo-version>` before `go mod tidy` to pin the exact version.

> This is a known limitation of the current module path and will be addressed permanently in a future major version.
