### PR TITLE
feat(wasm): add AddEventListenerWithEvent helper to expose browser ev…

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CURRENT_VERSION string = "v2.16.2"
+var CURRENT_VERSION string = "v2.16.3"
 
 // CURRENT_COMMIT is the Go pseudo-version of the gothicframework module that
 // ships with this binary. Used by init to pin the exact version before go mod
@@ -17,7 +17,7 @@ var CURRENT_VERSION string = "v2.16.2"
 // Update this alongside CURRENT_VERSION on every release using:
 //
 //	GOWORK=off go list -m github.com/felipegenef/gothicframework@<short-hash>
-var CURRENT_COMMIT string = "v0.0.0-20260525184758-edc8106ea11e"
+var CURRENT_COMMIT string = "v0.0.0-20260525192519-ba1201e4b734"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/pkg/wasm/stubs.go
+++ b/pkg/wasm/stubs.go
@@ -140,6 +140,47 @@ func CopyBytesToGo(dst []byte, src JSValue) int { return 0 }
 // Server-side no-op.
 func TriggerDownload(filename string, data []byte, mimeType string) {}
 
+// AddEventListenerWithEvent attaches a persistent event listener to el for the given event name.
+// fn receives the browser Event object as a JSValue, giving access to event properties and methods.
+// Use this when you need to inspect or interact with the event itself — call preventDefault,
+// read event.target, event.key, event.clientX, event.detail, etc.
+// The listener stays alive for the lifetime of the page — it is never removed automatically.
+//
+// Example:
+//
+//	AddEventListenerWithEvent(form, "submit", func(e JSValue) {
+//	    e.Call("preventDefault")               // stop the default form submission
+//	    val := e.Get("target").Get("value").String()
+//	})
+//
+//	AddEventListenerWithEvent(Document(), "keydown", func(e JSValue) {
+//	    if e.Get("key").String() == "Escape" {
+//	        // close modal, etc.
+//	    }
+//	})
+func AddEventListenerWithEvent(el JSValue, event string, fn func(JSValue)) {}
+
+// AddEventListener attaches a persistent event listener to el for the given event name.
+// fn is called with no arguments each time the event fires.
+// The listener stays alive for the lifetime of the page — it is never removed automatically.
+//
+// Common use cases: reacting to browser events (click, input, toggle) or framework
+// events (htmx:afterSwap, htmx:beforeSwap) on any JSValue element including Document()
+// and Window().
+//
+// Example:
+//
+//	body := Document().Get("body")
+//	AddEventListener(body, "htmx:afterSwap", func() {
+//	    // re-sync DOM after HTMX swaps content
+//	})
+//
+//	details := QuerySelector("details#menu")
+//	AddEventListener(details, "toggle", func() {
+//	    // react to open/close state changes
+//	})
+func AddEventListener(el JSValue, event string, fn func()) {}
+
 // Element tree helpers — server-side no-ops.
 func AppendChild(parent, child JSValue) {}
 func RemoveElement(el JSValue)          {}

--- a/pkg/wasm/wasm-runtime/runtime/dom.go
+++ b/pkg/wasm/wasm-runtime/runtime/dom.go
@@ -457,6 +457,37 @@ func TriggerDownload(filename string, data []byte, mimeType string) {
 	js.Global().Get("URL").Call("revokeObjectURL", url)
 }
 
+// AddEventListenerWithEvent attaches a persistent event listener to el for the given event name.
+// fn receives the browser Event object as a JSValue, giving access to event properties and methods
+// such as preventDefault(), stopPropagation(), event.target, event.key, event.detail, etc.
+// The js.Func is retained in keep and never released — persistent listeners must stay
+// alive for the lifetime of the page; releasing them would panic on the next event.
+func AddEventListenerWithEvent(el JSValue, event string, fn func(JSValue)) {
+	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		var ev JSValue
+		if len(args) > 0 {
+			ev = JSValue{args[0]}
+		}
+		fn(ev)
+		return nil
+	})
+	keep = append(keep, f)
+	el.v.Call("addEventListener", event, f)
+}
+
+// AddEventListener attaches a persistent event listener to el for the given event name.
+// fn is called with no arguments each time the event fires.
+// The js.Func is retained in keep and never released — persistent listeners must stay
+// alive for the lifetime of the page; releasing them would panic on the next event.
+func AddEventListener(el JSValue, event string, fn func()) {
+	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		fn()
+		return nil
+	})
+	keep = append(keep, f)
+	el.v.Call("addEventListener", event, f)
+}
+
 // Element tree helpers.
 func AppendChild(parent, child JSValue) { parent.v.Call("appendChild", child.v) }
 func RemoveElement(el JSValue)          { el.v.Call("remove") }

--- a/pkg/wasm/wasm-runtime/runtime/dom_stub.go
+++ b/pkg/wasm/wasm-runtime/runtime/dom_stub.go
@@ -57,6 +57,9 @@ func CopyBytesToGo(dst []byte, src JSValue) int { return 0 }
 
 func TriggerDownload(filename string, data []byte, mimeType string) {}
 
+func AddEventListenerWithEvent(el JSValue, event string, fn func(JSValue)) {}
+func AddEventListener(el JSValue, event string, fn func())                 {}
+
 func AppendChild(parent, child JSValue) {}
 func RemoveElement(el JSValue)          {}
 func ClickElement(el JSValue)           {}


### PR DESCRIPTION
# Patch Notes — v2.16.3

## New Features

### `AddEventListener` — attach a persistent DOM event listener
**Files:** `pkg/wasm/stubs.go`, `pkg/wasm/wasm-runtime/runtime/dom.go`, `pkg/wasm/wasm-runtime/runtime/dom_stub.go`

Attaches a persistent event listener to any `JSValue` element. The callback is a plain `func()` with no arguments — use this when you only care that the event fired, not about any data on the event itself.

The underlying `js.Func` is retained in the module-level `keep` slice and never released. Releasing a persistent listener would cause a panic on the next event, so this is intentional by design.

```go
body := Document().Get("body")
AddEventListener(body, "htmx:afterSwap", func() {
    // re-sync DOM after HTMX swaps content
})

details := QuerySelector("details#menu")
AddEventListener(details, "toggle", func() {
    // react to open/close state changes
})
```

---

### `AddEventListenerWithEvent` — attach a persistent DOM event listener with access to the event object
**Files:** `pkg/wasm/stubs.go`, `pkg/wasm/wasm-runtime/runtime/dom.go`, `pkg/wasm/wasm-runtime/runtime/dom_stub.go`

Like `AddEventListener` but passes the browser `Event` object to the callback as a `JSValue`. Use this when you need to inspect or act on the event — call `preventDefault`, read `event.target`, `event.key`, `event.detail`, `event.clientX`, etc.

```go
form := GetElementById("my-form")
AddEventListenerWithEvent(form, "submit", func(e JSValue) {
    e.Call("preventDefault")                         // stop default form submission
    val := e.Get("target").Get("value").String()
})

AddEventListenerWithEvent(Document(), "keydown", func(e JSValue) {
    if e.Get("key").String() == "Escape" {
        // close modal, etc.
    }
})

detailsEl := QuerySelector("details#menu")
AddEventListenerWithEvent(detailsEl, "gothic:detail", func(e JSValue) {
    msg := e.Get("detail").Get("msg").String()       // read structured CustomEvent payload
    SetText("status", msg)
})
```

---