### PR TITLE
fix: hx-boost WASM re-init and same-package cache invalidation (v2.16.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ main
 main.exe
 gothicframework
 gothicframework.exe
+.claude/

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CURRENT_VERSION string = "v2.16.3"
+var CURRENT_VERSION string = "v2.16.4"
 
 // CURRENT_COMMIT is the Go pseudo-version of the gothicframework module that
 // ships with this binary. Used by init to pin the exact version before go mod

--- a/pkg/helpers/routes/wasm_bootstrap.go
+++ b/pkg/helpers/routes/wasm_bootstrap.go
@@ -62,7 +62,12 @@ func injectWasmBootstrap(html []byte, wasmName string, compression CompressionMe
 	// consistency. For fragments we use the instance id to look up the wrapper.
 	var findEl string
 	if isFullPage {
-		findEl = `document.querySelector('body[data-gothic-wasm="` + wasmName + `"]')`
+		// After hx-boost navigation, HTMX swaps body innerHTML but not body element
+		// attributes — so body still carries the previous page's data-gothic-wasm.
+		// Fall back to document.body and update its attribute so the scope stamp
+		// and WASM bootstrap work correctly on every navigation.
+		findEl = `(document.querySelector('body[data-gothic-wasm="` + wasmName + `"]')||` +
+			`(function(){var b=document.body;if(b)b.setAttribute('data-gothic-wasm','` + wasmName + `');return b;})())`
 	} else {
 		findEl = `(document.currentScript&&document.currentScript.previousElementSibling)` +
 			`||document.querySelector('[data-gothic-wasm="` + wasmName + `"][data-gothic-inst="` + inst + `"]')`

--- a/pkg/helpers/routes/wasm_bootstrap_test.go
+++ b/pkg/helpers/routes/wasm_bootstrap_test.go
@@ -253,3 +253,91 @@ func TestInjectWasmEnvelope_UniqueAcrossCalls(t *testing.T) {
 		t.Errorf("envelope B's selector does not carry envelope B's instance id: %s", b)
 	}
 }
+
+// TestInjectWasmBootstrap_HxBoostFallbackSelector is a regression guard for the
+// hx-boost navigation fix. When HTMX boosts a navigation it swaps the <body>
+// innerHTML but NOT the <body> element's attributes, so the new page's body
+// still carries the previous page's data-gothic-wasm value. Without a
+// fallback, document.querySelector('body[data-gothic-wasm="<new>"]') returns
+// null and WASM bootstrap silently no-ops on every boosted navigation.
+//
+// The fix wraps the primary selector in a `(querySelector(...) || fallback())`
+// expression where the fallback grabs document.body and updates its
+// data-gothic-wasm attribute to the current page's wasm name. This test must
+// FAIL if the findEl JS is ever reverted to the pre-fix single-selector form.
+func TestInjectWasmBootstrap_HxBoostFallbackSelector(t *testing.T) {
+	const wasmName = "login-page"
+	in := []byte(`<html><body data-gothic-wasm="some-previous-page">x</body></html>`)
+	out := injectWasmBootstrap(in, wasmName, GZIP, GothicTinyGo, "abc")
+
+	// Branch 1: the primary selector must still target a body that already
+	// carries the correct data-gothic-wasm (the non-boosted, fresh-load case).
+	primary := `document.querySelector('body[data-gothic-wasm="` + wasmName + `"]')`
+	if !bytes.Contains(out, []byte(primary)) {
+		t.Errorf("expected primary selector %q in bootstrap, got: %s", primary, out)
+	}
+
+	// Branch 2: the fallback must stamp the current wasmName onto document.body
+	// so post-hx-boost navigations heal the attribute and bootstrap succeeds.
+	fallback := `setAttribute('data-gothic-wasm','` + wasmName + `')`
+	if !bytes.Contains(out, []byte(fallback)) {
+		t.Errorf("expected hx-boost fallback %q in bootstrap, got: %s", fallback, out)
+	}
+
+	// And the fallback must consult document.body — not, say, document.head —
+	// because hx-boost swaps body innerHTML.
+	if !bytes.Contains(out, []byte(`document.body`)) {
+		t.Errorf("expected fallback to consult document.body, got: %s", out)
+	}
+
+	// Extract the findEl expression — the right-hand side of `var el=(...);` —
+	// and assert it is a single, syntactically self-contained JS expression so
+	// the inline `var el=(<findEl>);` assignment cannot break the bootstrap
+	// script. We use a regex anchored on the surrounding `var el=(` / `);`
+	// markers that wrap findEl in the generated template.
+	re := regexp.MustCompile(`var el=\(([\s\S]*?)\);\s*if\(!el\)return;`)
+	m := re.FindSubmatch(out)
+	if m == nil {
+		t.Fatalf("could not locate `var el=(<findEl>);` in bootstrap output: %s", out)
+	}
+	findEl := m[1]
+
+	// Both branches must live inside the findEl expression, not somewhere else
+	// in the script. A revert to the pre-fix form would drop the fallback from
+	// here and this assertion would fail.
+	if !bytes.Contains(findEl, []byte(primary)) {
+		t.Errorf("findEl expression missing primary selector branch; got %q", findEl)
+	}
+	if !bytes.Contains(findEl, []byte(fallback)) {
+		t.Errorf("findEl expression missing hx-boost fallback branch; got %q", findEl)
+	}
+
+	// The two branches must be joined by `||` so the fallback only fires when
+	// the primary selector returns null. Any other join (`&&`, `;`, etc.) would
+	// either be a syntax error or change the semantics.
+	if !bytes.Contains(findEl, []byte(`||`)) {
+		t.Errorf("findEl branches must be joined by ||, got %q", findEl)
+	}
+
+	// Bracket balance check: the findEl expression must be a single self-
+	// contained expression with no unclosed parens/braces/brackets and no
+	// stray top-level semicolons that would break `var el=(<findEl>);`.
+	if open, close := bytes.Count(findEl, []byte("(")), bytes.Count(findEl, []byte(")")); open != close {
+		t.Errorf("findEl has unbalanced parens (%d open, %d close): %q", open, close, findEl)
+	}
+	if open, close := bytes.Count(findEl, []byte("{")), bytes.Count(findEl, []byte("}")); open != close {
+		t.Errorf("findEl has unbalanced braces (%d open, %d close): %q", open, close, findEl)
+	}
+	if open, close := bytes.Count(findEl, []byte("[")), bytes.Count(findEl, []byte("]")); open != close {
+		t.Errorf("findEl has unbalanced brackets (%d open, %d close): %q", open, close, findEl)
+	}
+	// Semicolons are only legal inside the fallback IIFE body, never at the
+	// expression's top level. The IIFE we emit contains exactly three ';'
+	// (after `var b=document.body`, after the `if(b)b.setAttribute(...)`
+	// statement, and after `return b`). More than three means a stray
+	// top-level semicolon snuck in and would break the wrapping
+	// `var el=(<findEl>);` assignment.
+	if n := bytes.Count(findEl, []byte(";")); n > 3 {
+		t.Errorf("findEl has too many semicolons (%d) — risk of breaking `var el=(...);`: %q", n, findEl)
+	}
+}

--- a/pkg/helpers/wasm/testdata/cache_phase_a/helper_test.go
+++ b/pkg/helpers/wasm/testdata/cache_phase_a/helper_test.go
@@ -1,0 +1,4 @@
+package fixtures
+
+// Mock test file. Hand-written hashing must EXCLUDE *_test.go files.
+var TestHelper = "ignored"

--- a/pkg/helpers/wasm/testdata/cache_phase_a/other_gen.go
+++ b/pkg/helpers/wasm/testdata/cache_phase_a/other_gen.go
@@ -1,0 +1,4 @@
+package fixtures
+
+// Mock generated file. Hand-written hashing must EXCLUDE *_gen.go files.
+var Generated = "ignored"

--- a/pkg/helpers/wasm/testdata/cache_phase_a/page_templ.go
+++ b/pkg/helpers/wasm/testdata/cache_phase_a/page_templ.go
@@ -1,0 +1,3 @@
+package fixtures
+
+// Mock generated templ file. Hand-written hashing must EXCLUDE this.

--- a/pkg/helpers/wasm/testdata/cache_phase_a/state.go
+++ b/pkg/helpers/wasm/testdata/cache_phase_a/state.go
@@ -1,0 +1,4 @@
+package fixtures
+
+// Hand-written sibling. Changes to this file must invalidate the page hash.
+var StateCounter = 42

--- a/pkg/helpers/wasm/wasm_cache.go
+++ b/pkg/helpers/wasm/wasm_cache.go
@@ -65,12 +65,63 @@ func (h *WasmHelper) pageInputHash(page WasmPage) string {
 	if data, err := os.ReadFile(page.SourceFile); err == nil {
 		hh.Write(data)
 	}
+	h.feedHandwrittenPackageFiles(hh, filepath.Dir(page.SourceFile), page.SourceFile)
 	h.feedTopicFiles(hh)
 	h.feedFile(hh, tmplWasmPageMain)
 	h.feedRuntimeFS(hh)
 	hh.Write([]byte{byte(page.Compression)})
 	hh.Write([]byte{byte(page.Compiler)})
 	return hex.EncodeToString(hh.Sum(nil))
+}
+
+// feedHandwrittenPackageFiles hashes hand-written .go files in the page's
+// package directory so changes to sibling files (e.g. state.go) invalidate the
+// per-page WASM cache. Generated files (*_templ.go, *_gen.go), test files
+// (*_test.go), and the page's own SourceFile (exclude) are skipped. Files are
+// processed in alphabetical order for determinism.
+func (h *WasmHelper) feedHandwrittenPackageFiles(hh io.Writer, dir string, exclude string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	absExclude, err := filepath.Abs(exclude)
+	if err != nil {
+		absExclude = exclude
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_templ.go") ||
+			strings.HasSuffix(name, "_gen.go") ||
+			strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		full := filepath.Join(dir, name)
+		absFull, err := filepath.Abs(full)
+		if err != nil {
+			absFull = full
+		}
+		if absFull == absExclude {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		hh.Write([]byte(name))
+		hh.Write([]byte{0})
+		hh.Write(data)
+	}
 }
 
 // topicManagerInputHash hashes all topic files, the manager template, and the compression method.

--- a/pkg/helpers/wasm/wasm_cache_test.go
+++ b/pkg/helpers/wasm/wasm_cache_test.go
@@ -1,10 +1,35 @@
 package helpers
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// writePageFixture creates a minimal page.go in dir and returns its absolute path.
+func writePageFixture(t *testing.T, dir string) string {
+	t.Helper()
+	src := filepath.Join(dir, "page.go")
+	if err := os.WriteFile(src, []byte("package fixtures\nvar Page = 1\n"), 0644); err != nil {
+		t.Fatalf("write page.go: %v", err)
+	}
+	return src
+}
+
+// handwrittenHash returns a hex SHA-256 over feedHandwrittenPackageFiles output.
+// Isolating just that helper keeps these tests focused and independent of
+// runtime/topic/template inputs which require cwd setup.
+func handwrittenHash(t *testing.T, dir, exclude string) string {
+	t.Helper()
+	h := DefaultWasmHelper()
+	var buf bytes.Buffer
+	h.feedHandwrittenPackageFiles(&buf, dir, exclude)
+	sum := sha256.Sum256(buf.Bytes())
+	return hex.EncodeToString(sum[:])
+}
 
 // withTempCwd sets cwd to a fresh temporary directory for the duration of the
 // test and restores the original working directory on cleanup.
@@ -73,5 +98,124 @@ func TestPageInputHash_DifferentCompressionChangesHash(t *testing.T) {
 	hBr := h.pageInputHash(page)
 	if hGz == hBr {
 		t.Errorf("expected different hashes for different compression; both were %q", hGz)
+	}
+}
+
+// TestFeedHandwrittenPackageFiles_StateGoInvalidates ensures that adding a
+// hand-written sibling state.go to the page's directory changes the hash.
+// This is the core stale-WASM-cache bugfix.
+func TestFeedHandwrittenPackageFiles_StateGoInvalidates(t *testing.T) {
+	dir := t.TempDir()
+	src := writePageFixture(t, dir)
+
+	hBefore := handwrittenHash(t, dir, src)
+
+	statePath := filepath.Join(dir, "state.go")
+	if err := os.WriteFile(statePath, []byte("package fixtures\nvar S = 1\n"), 0644); err != nil {
+		t.Fatalf("write state.go: %v", err)
+	}
+	hAfter := handwrittenHash(t, dir, src)
+
+	if hBefore == hAfter {
+		t.Errorf("expected hash to change when state.go is added; both were %q", hBefore)
+	}
+}
+
+// TestFeedHandwrittenPackageFiles_ModifyingStateChangesHash ensures that
+// editing the contents of a sibling hand-written file invalidates the hash.
+func TestFeedHandwrittenPackageFiles_ModifyingStateChangesHash(t *testing.T) {
+	dir := t.TempDir()
+	src := writePageFixture(t, dir)
+	statePath := filepath.Join(dir, "state.go")
+	if err := os.WriteFile(statePath, []byte("package fixtures\nvar S = 1\n"), 0644); err != nil {
+		t.Fatalf("write state.go: %v", err)
+	}
+	hBefore := handwrittenHash(t, dir, src)
+
+	if err := os.WriteFile(statePath, []byte("package fixtures\nvar S = 2\n"), 0644); err != nil {
+		t.Fatalf("rewrite state.go: %v", err)
+	}
+	hAfter := handwrittenHash(t, dir, src)
+
+	if hBefore == hAfter {
+		t.Errorf("expected hash to change when state.go content changes; both were %q", hBefore)
+	}
+}
+
+// TestFeedHandwrittenPackageFiles_GenFilesExcluded ensures that *_gen.go
+// (generated) sibling files do NOT contribute to the hash.
+func TestFeedHandwrittenPackageFiles_GenFilesExcluded(t *testing.T) {
+	dir := t.TempDir()
+	src := writePageFixture(t, dir)
+	hBefore := handwrittenHash(t, dir, src)
+
+	genPath := filepath.Join(dir, "other_gen.go")
+	if err := os.WriteFile(genPath, []byte("package fixtures\nvar G = 1\n"), 0644); err != nil {
+		t.Fatalf("write other_gen.go: %v", err)
+	}
+	// Also include _templ.go since it is in the same exclusion family.
+	templPath := filepath.Join(dir, "page_templ.go")
+	if err := os.WriteFile(templPath, []byte("package fixtures\nvar T = 1\n"), 0644); err != nil {
+		t.Fatalf("write page_templ.go: %v", err)
+	}
+	hAfter := handwrittenHash(t, dir, src)
+
+	if hBefore != hAfter {
+		t.Errorf("expected hash to be unchanged when generated files are added; got %q vs %q", hBefore, hAfter)
+	}
+}
+
+// TestFeedHandwrittenPackageFiles_TestFilesExcluded ensures that *_test.go
+// sibling files do NOT contribute to the hash.
+func TestFeedHandwrittenPackageFiles_TestFilesExcluded(t *testing.T) {
+	dir := t.TempDir()
+	src := writePageFixture(t, dir)
+	hBefore := handwrittenHash(t, dir, src)
+
+	testPath := filepath.Join(dir, "helper_test.go")
+	if err := os.WriteFile(testPath, []byte("package fixtures\nvar X = 1\n"), 0644); err != nil {
+		t.Fatalf("write helper_test.go: %v", err)
+	}
+	hAfter := handwrittenHash(t, dir, src)
+
+	if hBefore != hAfter {
+		t.Errorf("expected hash to be unchanged when test files are added; got %q vs %q", hBefore, hAfter)
+	}
+}
+
+// TestFeedHandwrittenPackageFiles_OrderingDeterministic ensures that two
+// directories holding the same hand-written sibling files produce the same
+// hash regardless of the order in which the files happened to be written
+// (which can influence directory iteration order on some filesystems). The
+// alphabetical sort inside feedHandwrittenPackageFiles guarantees this.
+func TestFeedHandwrittenPackageFiles_OrderingDeterministic(t *testing.T) {
+	contents := map[string][]byte{
+		"a_state.go":  []byte("package fixtures\nvar A = 1\n"),
+		"m_middle.go": []byte("package fixtures\nvar M = 1\n"),
+		"z_last.go":   []byte("package fixtures\nvar Z = 1\n"),
+	}
+
+	// Dir 1: write a, m, z.
+	dir1 := t.TempDir()
+	src1 := writePageFixture(t, dir1)
+	for _, name := range []string{"a_state.go", "m_middle.go", "z_last.go"} {
+		if err := os.WriteFile(filepath.Join(dir1, name), contents[name], 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	// Dir 2: write z, m, a (reverse order).
+	dir2 := t.TempDir()
+	src2 := writePageFixture(t, dir2)
+	for _, name := range []string{"z_last.go", "m_middle.go", "a_state.go"} {
+		if err := os.WriteFile(filepath.Join(dir2, name), contents[name], 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	h1 := handwrittenHash(t, dir1, src1)
+	h2 := handwrittenHash(t, dir2, src2)
+	if h1 != h2 {
+		t.Errorf("expected identical hashes regardless of write order; got %q vs %q", h1, h2)
 	}
 }


### PR DESCRIPTION
# Gothic Framework v2.16.4

## Bug Fixes

### WASM bootstrap no longer breaks after hx-boost navigation

Pages using [hx-boost](https://htmx.org/attributes/hx-boost/) (HTMX's body-swap navigation) would silently fail to initialise WASM on the destination page. The bootstrap script now correctly detects and stamps the new body after a swap, so WASM initialises reliably on every navigation — not just on hard loads.

**Affected users:** any project using `hx-boost="true"` on pages that have `ClientSideState`.

### WASM cache now invalidates when same-package helper files change

Previously, only the file directly containing `ClientSideState` was included in the WASM build cache hash. Changes to sibling files in the same package — such as a `state.go` helper — were silently ignored, serving stale WASM until a full rebuild was forced.

The cache hash now includes all hand-written `.go` files in the same package directory, while correctly excluding generated files (`*_templ.go`, `*_gen.go`) and test files (`*_test.go`) to avoid spurious invalidations.

**Affected users:** any project that defines shared helpers or observables in a separate `.go` file alongside a `ClientSideState` page.

## Upgrade

```bash
go install github.com/felipegenef/gothicframework@latest
```

No breaking changes. No migration required.
