### PR TITLE
release v2.17.1: per-symbol WASM cache hashing

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,8 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CURRENT_VERSION string = "v2.17.0"
-
+var CURRENT_VERSION string = "v2.17.1"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/pkg/helpers/wasm/wasm.go
+++ b/pkg/helpers/wasm/wasm.go
@@ -56,6 +56,12 @@ type WasmPage struct {
 	// WASM cache to invalidate when a transitively imported local package
 	// changes on disk. Sorted alphabetically and de-duplicated by the scanner.
 	LocalPackageDirs []string
+	// UsedDeclSources contains the formatted Go source of each AST declaration
+	// (func/const/type) that the page's ClientSideState body transitively
+	// references in its own package. Sorted alphabetically for hash stability.
+	// Used by the WASM cache to invalidate only when a referenced symbol's
+	// source actually changes, rather than any file in the package.
+	UsedDeclSources []string
 }
 
 func NewWasmHelper(goos, goarch string) WasmHelper {

--- a/pkg/helpers/wasm/wasm_cache.go
+++ b/pkg/helpers/wasm/wasm_cache.go
@@ -65,7 +65,14 @@ func (h *WasmHelper) pageInputHash(page WasmPage) string {
 	if data, err := os.ReadFile(page.SourceFile); err == nil {
 		hh.Write(data)
 	}
-	h.feedHandwrittenPackageFiles(hh, filepath.Dir(page.SourceFile), page.SourceFile)
+	// Phase 12: per-symbol hashing for the page's own package. Instead of
+	// hashing every hand-written .go file in the page's directory, hash only
+	// the formatted source of the AST decls the page's ClientSideState body
+	// actually references. UsedDeclSources is pre-sorted by the scanner.
+	for _, src := range page.UsedDeclSources {
+		io.WriteString(hh, src)
+		io.WriteString(hh, "\x00")
+	}
 	// Hash hand-written files in every local package contributing helpers to
 	// this page, so changes in cross-package dependencies invalidate the cache.
 	// page.LocalPackageDirs is pre-sorted by the scanner for determinism.

--- a/pkg/helpers/wasm/wasm_cache_test.go
+++ b/pkg/helpers/wasm/wasm_cache_test.go
@@ -338,3 +338,115 @@ func TestFeedHandwrittenPackageFiles_OrderingDeterministic(t *testing.T) {
 		t.Errorf("expected identical hashes regardless of write order; got %q vs %q", h1, h2)
 	}
 }
+
+// Phase 12 — Per-symbol cache hashing tests. These exercise the
+// UsedDeclSources path in pageInputHash directly by constructing WasmPage
+// values with pre-populated decl sources, bypassing the scanner.
+
+// TestPageInputHash_UsedDeclSources_ValueChangeInvalidates ensures that
+// changing the source of a tracked decl (e.g. const value) flips the hash.
+func TestPageInputHash_UsedDeclSources_ValueChangeInvalidates(t *testing.T) {
+	dir := withTempCwd(t)
+	srcPath := filepath.Join(dir, "page.go")
+	if err := os.WriteFile(srcPath, []byte("package x\n"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	h := DefaultWasmHelper()
+	pageBefore := WasmPage{
+		SourceFile:      srcPath,
+		Compression:     WasmCompressionGzip,
+		UsedDeclSources: []string{"const CounterStep = 5"},
+	}
+	pageAfter := WasmPage{
+		SourceFile:      srcPath,
+		Compression:     WasmCompressionGzip,
+		UsedDeclSources: []string{"const CounterStep = 6"},
+	}
+	before := h.pageInputHash(pageBefore)
+	after := h.pageInputHash(pageAfter)
+	if before == after {
+		t.Errorf("expected hash to change when a tracked decl source changes; both were %q", before)
+	}
+}
+
+// TestPageInputHash_UsedDeclSources_UnrelatedSymbolsIgnored ensures that
+// symbols which aren't in UsedDeclSources do NOT affect the hash. This is the
+// whole point of per-symbol hashing — sibling decls the page doesn't use are
+// transparent to the cache.
+func TestPageInputHash_UsedDeclSources_UnrelatedSymbolsIgnored(t *testing.T) {
+	dir := withTempCwd(t)
+	srcPath := filepath.Join(dir, "page.go")
+	if err := os.WriteFile(srcPath, []byte("package x\n"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	h := DefaultWasmHelper()
+	page := WasmPage{
+		SourceFile:      srcPath,
+		Compression:     WasmCompressionGzip,
+		UsedDeclSources: []string{"const CounterStep = 5"},
+	}
+	// Writing an unrelated state.go to the same dir must NOT change the hash
+	// now that pageInputHash no longer hashes the whole package directory.
+	before := h.pageInputHash(page)
+	statePath := filepath.Join(dir, "state.go")
+	if err := os.WriteFile(statePath, []byte("package x\nconst Unrelated = 42\n"), 0644); err != nil {
+		t.Fatalf("write state.go: %v", err)
+	}
+	after := h.pageInputHash(page)
+	if before != after {
+		t.Errorf("expected hash unchanged when unrelated sibling decl appears; got %q vs %q", before, after)
+	}
+}
+
+// TestPageInputHash_UsedDeclSources_HelperBodyChangeInvalidates ensures that
+// a func helper's body change (different formatted source) flips the hash.
+func TestPageInputHash_UsedDeclSources_HelperBodyChangeInvalidates(t *testing.T) {
+	dir := withTempCwd(t)
+	srcPath := filepath.Join(dir, "page.go")
+	if err := os.WriteFile(srcPath, []byte("package x\n"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	h := DefaultWasmHelper()
+	pageBefore := WasmPage{
+		SourceFile:      srcPath,
+		Compression:     WasmCompressionGzip,
+		UsedDeclSources: []string{"func Foo() int { return 1 }"},
+	}
+	pageAfter := WasmPage{
+		SourceFile:      srcPath,
+		Compression:     WasmCompressionGzip,
+		UsedDeclSources: []string{"func Foo() int { return 2 }"},
+	}
+	before := h.pageInputHash(pageBefore)
+	after := h.pageInputHash(pageAfter)
+	if before == after {
+		t.Errorf("expected hash to change when helper body changes; both were %q", before)
+	}
+}
+
+// TestPageInputHash_UsedDeclSources_Deterministic ensures that repeated hash
+// calls over the same WasmPage yield identical results — sort stability and
+// hashing should be deterministic.
+func TestPageInputHash_UsedDeclSources_Deterministic(t *testing.T) {
+	dir := withTempCwd(t)
+	srcPath := filepath.Join(dir, "page.go")
+	if err := os.WriteFile(srcPath, []byte("package x\n"), 0644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	h := DefaultWasmHelper()
+	page := WasmPage{
+		SourceFile:  srcPath,
+		Compression: WasmCompressionGzip,
+		UsedDeclSources: []string{
+			"const A = 1",
+			"const B = 2",
+			"func F() int { return 3 }",
+		},
+	}
+	h1 := h.pageInputHash(page)
+	h2 := h.pageInputHash(page)
+	h3 := h.pageInputHash(page)
+	if h1 != h2 || h2 != h3 {
+		t.Errorf("expected deterministic hash across calls; got %q %q %q", h1, h2, h3)
+	}
+}

--- a/pkg/helpers/wasm/wasm_scan.go
+++ b/pkg/helpers/wasm/wasm_scan.go
@@ -111,6 +111,20 @@ func (h *WasmHelper) scanFile(path string) (WasmPage, bool, error) {
 		helpers = append(helpers, src)
 	}
 
+	// Build a sorted, deterministic snapshot of the same-package decl sources
+	// for the WASM cache. Only decls that belong to the page's own package
+	// (i.e. those returned by ExtractUsedHelpers) are included — cross-package
+	// dependencies are covered separately by LocalPackageDirs hashing.
+	usedDeclSources := make([]string, 0, len(helperDecls))
+	for _, d := range helperDecls {
+		src, err := astx.FormatNode(d, h.astLoader.Fset)
+		if err != nil {
+			return WasmPage{}, false, fmt.Errorf("wasm: format used decl in %s: %w", path, err)
+		}
+		usedDeclSources = append(usedDeclSources, src)
+	}
+	sort.Strings(usedDeclSources)
+
 	// Format body (outer braces stripped by FormatNode for *ast.BlockStmt).
 	body, err := astx.FormatNode(res.Body, h.astLoader.Fset)
 	if err != nil {
@@ -162,6 +176,7 @@ func (h *WasmHelper) scanFile(path string) (WasmPage, bool, error) {
 		Compression:      compression,
 		Compiler:         compiler,
 		LocalPackageDirs: localPackageDirs,
+		UsedDeclSources:  usedDeclSources,
 	}, true, nil
 }
 


### PR DESCRIPTION
# Patch Notes — v2.17.1

## Improvements

### WASM cache — per-symbol hashing replaces whole-file hashing
**Files:** `pkg/helpers/wasm/wasm_cache.go`, `pkg/helpers/wasm/wasm_scan.go`, `pkg/helpers/wasm/wasm.go`

The WASM cache now hashes only the specific declarations that each page's `ClientSideState` actually uses, rather than every non-generated `.go` file in the package. This eliminates spurious rebuilds when unrelated code in the same package changes.

**Before (v2.17.0):** changing any symbol in `state.go` would rebuild the WASM for every page in the package, even pages that don't use the changed symbol.

**After (v2.17.1-beta.1):** only pages that directly use the changed declaration are rebuilt.

```
// state.go
const CounterStep = 5   // ← change this → only /counter rebuilds
const UnusedValue = 42  // ← change this → no rebuilds at all
```

**How it works:** `ExtractUsedHelpers` already returned the exact `[]ast.Decl` nodes each page uses. These are now serialised via `go/format`, sorted for determinism, and stored on `WasmPage.UsedDeclSources`. The cache hashes those source strings instead of whole files.

Cache Phase B (external local package hashing, added in v2.17.0) is unchanged — it still hashes whole files for imported packages, which is correct because the per-symbol extraction only operates on same-package helpers.
