### PR TITLE
feat(wasm): automate wasm-opt install, add topic compiler choice, and refine cache surgicality

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CURRENT_VERSION string = "v2.17.1"
+var CURRENT_VERSION string = "v2.17.2"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/pkg/helpers/wasm/wasm.go
+++ b/pkg/helpers/wasm/wasm.go
@@ -8,17 +8,19 @@ import (
 )
 
 const tinyGoVersion = "0.41.1"
+const binaryenVersion = "117"
 
 // WasmHelper manages the TinyGo toolchain and compiles WASM pages.
 // It follows the same struct + method pattern as TailwindHelper and FileBasedRouteHelper.
 type WasmHelper struct {
-	Template       helpers.TemplateHelper
-	Runtime        string
-	Arch           string
-	Version        string
-	ConfigOverride string
-	cache          *wasmCache
-	astLoader      *astx.Loader
+	Template        helpers.TemplateHelper
+	Runtime         string
+	Arch            string
+	Version         string
+	BinaryenVersion string
+	ConfigOverride  string
+	cache           *wasmCache
+	astLoader       *astx.Loader
 }
 
 // WasmCompression is the compression algorithm for compiled WASM output.
@@ -66,10 +68,11 @@ type WasmPage struct {
 
 func NewWasmHelper(goos, goarch string) WasmHelper {
 	return WasmHelper{
-		Template: helpers.NewTemplateHelper(),
-		Runtime:  goos,
-		Arch:     goarch,
-		Version:  tinyGoVersion,
+		Template:        helpers.NewTemplateHelper(),
+		Runtime:         goos,
+		Arch:            goarch,
+		Version:         tinyGoVersion,
+		BinaryenVersion: binaryenVersion,
 	}
 }
 

--- a/pkg/helpers/wasm/wasm_binary.go
+++ b/pkg/helpers/wasm/wasm_binary.go
@@ -9,10 +9,13 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Binary lifecycle: TinyGo toolchain download, install, verification, and
@@ -20,6 +23,7 @@ import (
 // WASM).
 
 var ensureBinaryMu sync.Mutex
+var ensureBinaryenMu sync.Mutex
 
 const (
 	wasmMaxRetries      = 3
@@ -42,6 +46,22 @@ func (h *WasmHelper) binaryName() (string, error) {
 	return name, nil
 }
 
+func (h *WasmHelper) binaryenBinaryName() (string, error) {
+	key := h.Runtime + "/" + h.Arch
+	names := map[string]string{
+		"linux/amd64":   fmt.Sprintf("binaryen-version_%s-x86_64-linux.tar.gz", h.BinaryenVersion),
+		"linux/arm64":   fmt.Sprintf("binaryen-version_%s-aarch64-linux.tar.gz", h.BinaryenVersion),
+		"darwin/amd64":  fmt.Sprintf("binaryen-version_%s-x86_64-macos.tar.gz", h.BinaryenVersion),
+		"darwin/arm64":  fmt.Sprintf("binaryen-version_%s-arm64-macos.tar.gz", h.BinaryenVersion),
+		"windows/amd64": fmt.Sprintf("binaryen-version_%s-x86_64-windows.tar.gz", h.BinaryenVersion),
+	}
+	name, ok := names[key]
+	if !ok {
+		return "", fmt.Errorf("unsupported platform %s/%s for Binaryen", h.Runtime, h.Arch)
+	}
+	return name, nil
+}
+
 func (h *WasmHelper) cacheDir() (string, error) {
 	base := os.Getenv("GOTHIC_CLI_CACHE_DIR")
 	if base == "" {
@@ -52,6 +72,27 @@ func (h *WasmHelper) cacheDir() (string, error) {
 		}
 	}
 	return filepath.Join(base, "gothic-cli", "tinygo"), nil
+}
+
+func (h *WasmHelper) BinaryenRoot() string {
+	dir, err := h.cacheDir()
+	if err != nil {
+		return ""
+	}
+	platform := h.Runtime + "-" + h.Arch
+	return filepath.Join(dir, "binaryen-"+h.BinaryenVersion, platform, "binaryen-version_"+h.BinaryenVersion)
+}
+
+func (h *WasmHelper) BinaryenBinary() string {
+	root := h.BinaryenRoot()
+	if root == "" {
+		return ""
+	}
+	name := "wasm-opt"
+	if h.Runtime == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(root, "bin", name)
 }
 
 func (h *WasmHelper) TinyGoRoot() string {
@@ -72,12 +113,114 @@ func (h *WasmHelper) TinyGoBinary() string {
 }
 
 func (h *WasmHelper) Environ() []string {
+	return h.EnvironWithWarn(nil)
+}
+
+func (h *WasmHelper) EnvironWithWarn(warnOnce *sync.Once) []string {
 	root := h.TinyGoRoot()
 	binDir := filepath.Join(root, "bin")
-	return []string{
+
+	binaryenBinDir := filepath.Join(h.BinaryenRoot(), "bin")
+
+	env := []string{
 		"TINYGOROOT=" + root,
-		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"PATH=" + binDir + string(os.PathListSeparator) + binaryenBinDir + string(os.PathListSeparator) + os.Getenv("PATH"),
 	}
+
+	// TinyGo 0.41.1 requires wasm-opt for -opt=s/z. If it's missing from both
+	// the system PATH and the managed tinygo/bin dir, and we haven't managed
+	// to download our own binaryen either, we set WASMOPT=false.
+	hasWasmOpt := false
+	if _, err := exec.LookPath("wasm-opt"); err == nil {
+		hasWasmOpt = true
+	} else if _, err := os.Stat(filepath.Join(binDir, "wasm-opt")); err == nil {
+		hasWasmOpt = true
+	} else if _, err := os.Stat(filepath.Join(binDir, "wasm-opt.exe")); err == nil {
+		hasWasmOpt = true
+	} else if _, err := os.Stat(h.BinaryenBinary()); err == nil {
+		hasWasmOpt = true
+	}
+
+	if !hasWasmOpt {
+		env = append(env, "WASMOPT=false")
+		if warnOnce != nil {
+			warnOnce.Do(func() {
+				wasmWarnf("wasm-opt not found; skipping optimization (WASMOPT=false). Install Binaryen for smaller binaries.")
+			})
+		}
+	}
+
+	return env
+}
+
+func (h *WasmHelper) EnsureBinaryen() error {
+	// If wasm-opt is already in PATH, we don't need to download it.
+	if _, err := exec.LookPath("wasm-opt"); err == nil {
+		return nil
+	}
+
+	if b := h.BinaryenBinary(); b != "" {
+		if _, err := os.Stat(b); err == nil {
+			return nil
+		}
+	}
+
+	ensureBinaryenMu.Lock()
+	defer ensureBinaryenMu.Unlock()
+
+	if b := h.BinaryenBinary(); b != "" {
+		if _, err := os.Stat(b); err == nil {
+			return nil
+		}
+	}
+
+	archiveName, err := h.binaryenBinaryName()
+	if err != nil {
+		return err
+	}
+
+	archiveURL := fmt.Sprintf(
+		"https://github.com/WebAssembly/binaryen/releases/download/version_%s/%s",
+		h.BinaryenVersion, archiveName,
+	)
+
+	fmt.Fprintf(os.Stderr, "wasm: wasm-opt not found — downloading Binaryen %s for %s/%s...\n",
+		h.BinaryenVersion, h.Runtime, h.Arch)
+
+	tmpArchive, err := h.downloadToTemp(archiveURL)
+	if err != nil {
+		return fmt.Errorf("wasm: download Binaryen: %w", err)
+	}
+	defer os.Remove(tmpArchive)
+
+	dir, err := h.cacheDir()
+	if err != nil {
+		return err
+	}
+
+	platform := h.Runtime + "-" + h.Arch
+	finalDir := filepath.Join(dir, "binaryen-"+h.BinaryenVersion, platform)
+	tmpDir := finalDir + ".tmp"
+
+	os.RemoveAll(tmpDir)
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return fmt.Errorf("wasm: mkdir: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "wasm: extracting Binaryen toolchain...")
+	if err := h.extractArchive(tmpArchive, tmpDir); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("wasm: extract: %w", err)
+	}
+
+	os.RemoveAll(finalDir)
+	if err := os.Rename(tmpDir, finalDir); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("wasm: install: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "wasm: Binaryen %s ready at %s\n", h.BinaryenVersion, h.BinaryenRoot())
+	return nil
 }
 
 func (h *WasmHelper) EnsureBinary() error {
@@ -88,10 +231,42 @@ func (h *WasmHelper) EnsureBinary() error {
 		return nil
 	}
 
-	if _, err := os.Stat(h.TinyGoBinary()); err == nil {
+	tinygoReady := func() bool {
+		_, err := os.Stat(h.TinyGoBinary())
+		return err == nil
+	}
+	binaryenReady := func() bool {
+		if _, err := exec.LookPath("wasm-opt"); err == nil {
+			return true
+		}
+		if b := h.BinaryenBinary(); b != "" {
+			if _, err := os.Stat(b); err == nil {
+				return true
+			}
+		}
+		return false
+	}
+
+	if tinygoReady() && binaryenReady() {
 		return nil
 	}
 
+	var g errgroup.Group
+	if !binaryenReady() {
+		g.Go(func() error {
+			if err := h.EnsureBinaryen(); err != nil {
+				fmt.Fprintf(os.Stderr, "wasm: WARNING — failed to ensure Binaryen (%v); build might be unoptimized\n", err)
+			}
+			return nil
+		})
+	}
+	if !tinygoReady() {
+		g.Go(h.ensureTinyGo)
+	}
+	return g.Wait()
+}
+
+func (h *WasmHelper) ensureTinyGo() error {
 	ensureBinaryMu.Lock()
 	defer ensureBinaryMu.Unlock()
 

--- a/pkg/helpers/wasm/wasm_build.go
+++ b/pkg/helpers/wasm/wasm_build.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	wasmexec "github.com/felipegenef/gothicframework/v2/pkg/data/wasm_exec"
 	wasmruntime "github.com/felipegenef/gothicframework/v2/pkg/wasm"
@@ -27,7 +28,7 @@ const (
 	tmplTopicManagerMain = EmbeddedTmplTopicManagerMain
 )
 
-func (h *WasmHelper) GeneratePage(page WasmPage, outDir string) error {
+func (h *WasmHelper) GeneratePage(page WasmPage, outDir string, warnOnce *sync.Once) error {
 	compressedExt := compressionExt(page.Compression)
 	var hash string
 	if h.cache != nil {
@@ -86,7 +87,7 @@ func (h *WasmHelper) GeneratePage(page WasmPage, outDir string) error {
 	}
 
 	pkg := "./" + filepath.Base(genDir) + "/"
-	cmd, err := h.buildCommandForCompiler(page.Compiler, pkg, absOutFile, tempModDir)
+	cmd, err := h.buildCommandForCompiler(page.Compiler, pkg, absOutFile, tempModDir, warnOnce)
 	if err != nil {
 		return err
 	}
@@ -94,20 +95,36 @@ func (h *WasmHelper) GeneratePage(page WasmPage, outDir string) error {
 	cmd.Stderr = os.Stderr
 
 	if err := runWithVendorFallback(cmd, tempModDir, func() (*exec.Cmd, error) {
-		return h.buildCommandForCompiler(page.Compiler, pkg, absOutFile, tempModDir)
+		return h.buildCommandForCompiler(page.Compiler, pkg, absOutFile, tempModDir, warnOnce)
 	}); err != nil {
 		return fmt.Errorf("wasm: build %s (%s): %w", page.OutputName, compilerLabel(page.Compiler), err)
 	}
 
 	wasmSize, _ := h.fileSize(absOutFile)
 
-	if _, err := exec.LookPath("wasm-opt"); err == nil {
+	wasmOpt := "wasm-opt"
+	if _, err := exec.LookPath(wasmOpt); err != nil {
+		wasmOpt = ""
+		if managed := h.BinaryenBinary(); managed != "" {
+			if _, err := os.Stat(managed); err == nil {
+				wasmOpt = managed
+			}
+		}
+	}
+
+	if wasmOpt != "" {
 		tmp := absOutFile + ".opt"
-		opt := exec.Command("wasm-opt", "-Oz", "--strip-debug", "-o", tmp, absOutFile)
+		opt := exec.Command(wasmOpt, "-Oz", "--strip-debug", "-o", tmp, absOutFile)
 		if err := opt.Run(); err == nil {
 			os.Rename(tmp, absOutFile)
 		} else {
 			os.Remove(tmp)
+		}
+	} else {
+		if warnOnce != nil {
+			warnOnce.Do(func() {
+				wasmWarnf("wasm-opt not found; skipping manual optimization pass. Install Binaryen for smaller binaries.")
+			})
 		}
 	}
 
@@ -130,7 +147,7 @@ func (h *WasmHelper) GeneratePage(page WasmPage, outDir string) error {
 // go.mod with module name "wasm-runtime") and pkg is the relative import path
 // ("./<genDir>/"). The runtime files use `//go:build js && wasm`, so both
 // TinyGo's -target=wasm and standard Go's GOOS=js GOARCH=wasm satisfy them.
-func (h *WasmHelper) buildCommandForCompiler(choice WasmCompilerChoice, pkg, absOutFile, tempModDir string) (*exec.Cmd, error) {
+func (h *WasmHelper) buildCommandForCompiler(choice WasmCompilerChoice, pkg, absOutFile, tempModDir string, warnOnce *sync.Once) (*exec.Cmd, error) {
 	switch choice {
 	case WasmCompilerLocalTinyGo:
 		tinygo, err := exec.LookPath("tinygo")
@@ -146,6 +163,18 @@ func (h *WasmHelper) buildCommandForCompiler(choice WasmCompilerChoice, pkg, abs
 		)
 		cmd.Dir = tempModDir
 		cmd.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=-mod=mod")
+		hasWasmOpt := false
+		if _, err := exec.LookPath("wasm-opt"); err == nil {
+			hasWasmOpt = true
+		} else if b := h.BinaryenBinary(); b != "" {
+			if _, err := os.Stat(b); err == nil {
+				hasWasmOpt = true
+				cmd.Env = append(cmd.Env, "PATH="+filepath.Dir(b)+string(os.PathListSeparator)+os.Getenv("PATH"))
+			}
+		}
+		if !hasWasmOpt {
+			cmd.Env = append(cmd.Env, "WASMOPT=false")
+		}
 		return cmd, nil
 
 	case WasmCompilerGolang:
@@ -177,7 +206,7 @@ func (h *WasmHelper) buildCommandForCompiler(choice WasmCompilerChoice, pkg, abs
 			pkg,
 		)
 		cmd.Dir = tempModDir
-		cmd.Env = append(os.Environ(), h.Environ()...)
+		cmd.Env = append(os.Environ(), h.EnvironWithWarn(warnOnce)...)
 		cmd.Env = append(cmd.Env, "GOWORK=off", "GOFLAGS=-mod=mod")
 		return cmd, nil
 	}
@@ -286,7 +315,9 @@ func (h *WasmHelper) GenerateAll(pages []WasmPage, outDir string) error {
 
 	h.cache = loadWasmCache()
 
-	if err := h.GenerateTopicManagers(outDir); err != nil {
+	warnOnce := &sync.Once{}
+
+	if err := h.GenerateTopicManagers(outDir, warnOnce); err != nil {
 		wasmErrorf("topic manager build failed: %v", err)
 	}
 
@@ -299,7 +330,7 @@ func (h *WasmHelper) GenerateAll(pages []WasmPage, outDir string) error {
 				return err
 			}
 			defer sem.Release(1)
-			return h.GeneratePage(page, outDir)
+			return h.GeneratePage(page, outDir, warnOnce)
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -363,7 +394,7 @@ func (h *WasmHelper) CopyWasmExec(destDir string) error {
 	return os.WriteFile(dst, wasmexec.Shim, 0644)
 }
 
-func (h *WasmHelper) GenerateTopicManagers(outDir string) error {
+func (h *WasmHelper) GenerateTopicManagers(outDir string, warnOnce *sync.Once) error {
 	snippets, structs, aliases, refAliases := h.collectTopicSnippets()
 	if !h.hasTopicStructs(structs) {
 		return nil
@@ -376,19 +407,19 @@ func (h *WasmHelper) GenerateTopicManagers(outDir string) error {
 		if s.KeyName == "" {
 			continue
 		}
-		if err := h.buildTopicManager(s, snippets, structs, aliases, refAliases, outDir); err != nil {
+		if err := h.buildTopicManager(s, snippets, structs, aliases, refAliases, outDir, warnOnce); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (h *WasmHelper) buildTopicManager(s structInfo, snippets []string, allStructs []structInfo, aliases map[string]string, refAliases map[string]typeRef, outDir string) error {
+func (h *WasmHelper) buildTopicManager(s structInfo, snippets []string, allStructs []structInfo, aliases map[string]string, refAliases map[string]typeRef, outDir string, warnOnce *sync.Once) error {
 	wasmName := "topic-" + s.KeyName
 	compression := s.Compression
 	var hash string
 	if h.cache != nil {
-		hash = h.topicManagerInputHash(compression)
+		hash = h.topicManagerInputHash(s)
 		outPath := filepath.Join(outDir, wasmName+".wasm"+compressionExt(compression))
 		if h.cache.upToDate(wasmName, hash) {
 			if _, err := os.Stat(outPath); err == nil {
@@ -451,34 +482,43 @@ func (h *WasmHelper) buildTopicManager(s structInfo, snippets []string, allStruc
 		return err
 	}
 
-	tinygo := h.TinyGoBinary()
-	if h.ConfigOverride != "" {
-		tinygo = h.ConfigOverride
-	}
-
 	pkg := "./" + filepath.Base(genDir) + "/"
-	buildCmd := func() (*exec.Cmd, error) {
-		c := exec.Command(tinygo, "build", "-no-debug", "-opt=z", "-o", absOutFile, "-target", "wasm", "-gc", "conservative", pkg)
-		c.Dir = tempModDir
-		c.Env = append(os.Environ(), h.Environ()...)
-		c.Env = append(c.Env, "GOWORK=off", "GOFLAGS=-mod=mod")
-		return c, nil
+	cmd, err := h.buildCommandForCompiler(s.Compiler, pkg, absOutFile, tempModDir, warnOnce)
+	if err != nil {
+		return err
 	}
-	cmd, _ := buildCmd()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	if err := runWithVendorFallback(cmd, tempModDir, buildCmd); err != nil {
-		return fmt.Errorf("wasm: tinygo build %s: %w", wasmName, err)
+	if err := runWithVendorFallback(cmd, tempModDir, func() (*exec.Cmd, error) {
+		return h.buildCommandForCompiler(s.Compiler, pkg, absOutFile, tempModDir, warnOnce)
+	}); err != nil {
+		return fmt.Errorf("wasm: tinygo build %s (%s): %w", wasmName, compilerLabel(s.Compiler), err)
 	}
 
 	wasmSize, _ := h.fileSize(absOutFile)
 
-	if _, err := exec.LookPath("wasm-opt"); err == nil {
+	wasmOpt := "wasm-opt"
+	if _, err := exec.LookPath(wasmOpt); err != nil {
+		wasmOpt = ""
+		if managed := h.BinaryenBinary(); managed != "" {
+			if _, err := os.Stat(managed); err == nil {
+				wasmOpt = managed
+			}
+		}
+	}
+
+	if wasmOpt != "" {
 		tmp := absOutFile + ".opt"
-		if opt := exec.Command("wasm-opt", "-Oz", "--strip-debug", "-o", tmp, absOutFile); opt.Run() == nil {
+		if opt := exec.Command(wasmOpt, "-Oz", "--strip-debug", "-o", tmp, absOutFile); opt.Run() == nil {
 			os.Rename(tmp, absOutFile)
 		} else {
 			os.Remove(tmp)
+		}
+	} else {
+		if warnOnce != nil {
+			warnOnce.Do(func() {
+				wasmWarnf("wasm-opt not found; skipping manual optimization pass. Install Binaryen for smaller binaries.")
+			})
 		}
 	}
 

--- a/pkg/helpers/wasm/wasm_cache.go
+++ b/pkg/helpers/wasm/wasm_cache.go
@@ -79,7 +79,7 @@ func (h *WasmHelper) pageInputHash(page WasmPage) string {
 	for _, dir := range page.LocalPackageDirs {
 		h.feedHandwrittenPackageFiles(hh, dir, "")
 	}
-	h.feedTopicFiles(hh)
+
 	h.feedEmbeddedTemplate(hh, tmplWasmPageMain)
 	h.feedRuntimeFS(hh)
 	hh.Write([]byte{byte(page.Compression)})
@@ -137,13 +137,18 @@ func (h *WasmHelper) feedHandwrittenPackageFiles(hh io.Writer, dir string, exclu
 	}
 }
 
-// topicManagerInputHash hashes all topic files, the manager template, and the compression method.
-func (h *WasmHelper) topicManagerInputHash(compression WasmCompression) string {
+// topicManagerInputHash hashes the topic's source directory, the manager template,
+// and the specific configuration (name, compression, compiler).
+func (h *WasmHelper) topicManagerInputHash(s structInfo) string {
 	hh := sha256.New()
-	h.feedTopicFiles(hh)
+	if sourceDir, _, ok := resolveTopicSourceDir(); ok {
+		h.feedHandwrittenPackageFiles(hh, sourceDir, "")
+	}
 	h.feedEmbeddedTemplate(hh, tmplTopicManagerMain)
 	h.feedRuntimeFS(hh)
-	hh.Write([]byte{byte(compression)})
+	hh.Write([]byte(s.Name))
+	hh.Write([]byte{byte(s.Compression)})
+	hh.Write([]byte{byte(s.Compiler)})
 	return hex.EncodeToString(hh.Sum(nil))
 }
 

--- a/pkg/helpers/wasm/wasm_log.go
+++ b/pkg/helpers/wasm/wasm_log.go
@@ -36,6 +36,10 @@ func wasmErrorf(format string, args ...any) {
 	fmt.Printf(wasmTimestamp()+" "+wasmTag+" "+ansiRed+format+ansiReset+"\n", args...)
 }
 
+func wasmWarnf(format string, args ...any) {
+	fmt.Printf(wasmTimestamp()+" "+wasmTag+" "+ansiYellow+format+ansiReset+"\n", args...)
+}
+
 // wasmBuildResult prints the coloured build-result line:
 //
 //	2006/01/02 15:04:05 WASM <name> → <rawSize> → <finalSize> (<compression>)

--- a/pkg/helpers/wasm/wasm_topic.go
+++ b/pkg/helpers/wasm/wasm_topic.go
@@ -170,6 +170,7 @@ func (h *WasmHelper) writeTopicKeyStubs(structs []structInfo, aliases map[string
 type topicMeta struct {
 	KeyName         string
 	Compression     WasmCompression
+	Compiler        WasmCompilerChoice
 	AccessorName    string // the variable name from "var X = CreateTopic(...)"
 	ComponentFnName string // overrides Add<StructName>Topic mount helper name
 }
@@ -236,6 +237,7 @@ func (h *WasmHelper) parseStructsFromSource(src string) (structs []structInfo, t
 				if meta, ok := topicMetas[si.Name]; ok {
 					si.KeyName = meta.KeyName
 					si.Compression = meta.Compression
+					si.Compiler = meta.Compiler
 					si.AccessorName = meta.AccessorName
 					si.ComponentFnName = meta.ComponentFnName
 				}
@@ -363,7 +365,7 @@ func collectCreateTopicMetas(f *ast.File) map[string]topicMeta {
 				if structName == "" {
 					continue
 				}
-				name, compression, subscriberFnName, componentFnName := parseTopicConfigArg(call.Args[1])
+				name, compression, compiler, subscriberFnName, componentFnName := parseTopicConfigArg(call.Args[1])
 				// Capture the var name (e.g. "PageTopic" from "var PageTopic = CreateTopic(...)").
 				// If the var is blank ("_") or missing, fall back to struct-derived name.
 				// No warning — blank identifier on disk is the CLI's own normalized form
@@ -378,7 +380,7 @@ func collectCreateTopicMetas(f *ast.File) map[string]topicMeta {
 				if subscriberFnName != "" {
 					accessorName = subscriberFnName
 				}
-				metas[structName] = topicMeta{KeyName: name, Compression: compression, AccessorName: accessorName, ComponentFnName: componentFnName}
+				metas[structName] = topicMeta{KeyName: name, Compression: compression, Compiler: compiler, AccessorName: accessorName, ComponentFnName: componentFnName}
 			}
 		}
 		return true
@@ -452,11 +454,12 @@ func parseCompressionExpr(expr ast.Expr) WasmCompression {
 	return WasmCompressionGzip
 }
 
-// parseTopicConfigArg pulls Name, Compression, SubscriberFnName, and ComponentFnName
+// parseTopicConfigArg pulls Name, Compression, Compiler, SubscriberFnName, and ComponentFnName
 // from a TopicConfig composite literal. Compression defaults to GZIP; "BROTLI"
 // (case-insensitive) → brotli.
-func parseTopicConfigArg(arg ast.Expr) (name string, compression WasmCompression, subscriberFnName string, componentFnName string) {
+func parseTopicConfigArg(arg ast.Expr) (name string, compression WasmCompression, compiler WasmCompilerChoice, subscriberFnName string, componentFnName string) {
 	compression = WasmCompressionGzip
+	compiler = WasmCompilerGothicTinyGo
 	cl, ok := arg.(*ast.CompositeLit)
 	if !ok {
 		return
@@ -479,6 +482,8 @@ func parseTopicConfigArg(arg ast.Expr) (name string, compression WasmCompression
 			}
 		case "Compression":
 			compression = parseCompressionExpr(kv.Value)
+		case "Compiler":
+			compiler = parseCompilerExpr(kv.Value)
 		case "SubscriberFnName":
 			if bl, ok := kv.Value.(*ast.BasicLit); ok && bl.Kind == token.STRING {
 				if unq, err := strconv.Unquote(bl.Value); err == nil {
@@ -494,6 +499,25 @@ func parseTopicConfigArg(arg ast.Expr) (name string, compression WasmCompression
 		}
 	}
 	return
+}
+
+func parseCompilerExpr(expr ast.Expr) WasmCompilerChoice {
+	var identName string
+	switch e := expr.(type) {
+	case *ast.Ident:
+		identName = e.Name
+	case *ast.SelectorExpr:
+		if e.Sel != nil {
+			identName = e.Sel.Name
+		}
+	}
+	switch identName {
+	case "LocalTinyGo":
+		return WasmCompilerLocalTinyGo
+	case "Golang":
+		return WasmCompilerGolang
+	}
+	return WasmCompilerGothicTinyGo
 }
 
 // normalizeTopicDeclarations rewrites every `var <AccessorName> = CreateTopic(`

--- a/pkg/helpers/wasm/wasm_types.go
+++ b/pkg/helpers/wasm/wasm_types.go
@@ -120,6 +120,7 @@ type structInfo struct {
 	Name            string
 	KeyName         string
 	Compression     WasmCompression
+	Compiler        WasmCompilerChoice
 	Fields          []fieldInfo
 	AccessorName    string // var name from "var X = CreateTopic(...)", falls back to struct-derived name
 	ComponentFnName string // overrides Add<StructName>Topic mount helper name

--- a/pkg/wasm/stubs.go
+++ b/pkg/wasm/stubs.go
@@ -242,14 +242,24 @@ const (
 	BROTLI Compression = iota
 )
 
+// WasmCompiler selects the WASM build toolchain for a topic.
+type WasmCompiler int
+
+const (
+	GothicTinyGo WasmCompiler = iota // default: embedded TinyGo binary
+	LocalTinyGo                      // system tinygo binary in PATH
+	Golang                           // GOOS=js GOARCH=wasm standard Go compiler
+)
+
 // TopicConfig holds per-topic configuration. The CLI AST scanner reads the
 // Name and Compression fields from CreateTopic call sites to drive code
 // generation.
 type TopicConfig struct {
 	Name             string
-	Compression      Compression // GZIP (default) or BROTLI
-	SubscriberFnName string      // overrides generated accessor func name (default: <StructName>Topic)
-	ComponentFnName  string      // overrides generated mount component func name (default: Add<StructName>Topic)
+	Compression      Compression  // GZIP (default) or BROTLI
+	Compiler         WasmCompiler // GothicTinyGo (default), LocalTinyGo, or Golang
+	SubscriberFnName string       // overrides generated accessor func name (default: <StructName>Topic)
+	ComponentFnName  string       // overrides generated mount component func name (default: Add<StructName>Topic)
 }
 
 // CreateTopic declares a topic. The CLI AST scanner detects this call and

--- a/pkg/wasm/wasm-runtime/runtime/topic.go
+++ b/pkg/wasm/wasm-runtime/runtime/topic.go
@@ -494,12 +494,22 @@ const (
 	BROTLI Compression = iota
 )
 
+// WasmCompiler selects the WASM build toolchain for a topic.
+type WasmCompiler int
+
+const (
+	GothicTinyGo WasmCompiler = iota // default: embedded TinyGo binary
+	LocalTinyGo                      // system tinygo binary in PATH
+	Golang                           // GOOS=js GOARCH=wasm standard Go compiler
+)
+
 // TopicConfig holds per-topic configuration.
 type TopicConfig struct {
 	Name             string
-	Compression      Compression // GZIP (default) or BROTLI
-	SubscriberFnName string      // overrides generated accessor func name (default: <StructName>Topic)
-	ComponentFnName  string      // overrides generated mount component func name (default: Add<StructName>Topic)
+	Compression      Compression  // GZIP (default) or BROTLI
+	Compiler         WasmCompiler // GothicTinyGo (default), LocalTinyGo, or Golang
+	SubscriberFnName string       // overrides generated accessor func name (default: <StructName>Topic)
+	ComponentFnName  string       // overrides generated mount component func name (default: Add<StructName>Topic)
 }
 
 // CreateTopic declares a topic. The CLI AST scanner detects this call and

--- a/pkg/wasm/wasm-runtime/runtime/topic_stub.go
+++ b/pkg/wasm/wasm-runtime/runtime/topic_stub.go
@@ -14,12 +14,22 @@ const (
 	BROTLI Compression = iota
 )
 
+// WasmCompiler selects the WASM build toolchain for a topic.
+type WasmCompiler int
+
+const (
+	GothicTinyGo WasmCompiler = iota // default: embedded TinyGo binary
+	LocalTinyGo                      // system tinygo binary in PATH
+	Golang                           // GOOS=js GOARCH=wasm standard Go compiler
+)
+
 // TopicConfig holds per-topic configuration.
 type TopicConfig struct {
 	Name             string
-	Compression      Compression // GZIP (default) or BROTLI
-	SubscriberFnName string      // overrides generated accessor func name (default: <StructName>Topic)
-	ComponentFnName  string      // overrides generated mount component func name (default: Add<StructName>Topic)
+	Compression      Compression  // GZIP (default) or BROTLI
+	Compiler         WasmCompiler // GothicTinyGo (default), LocalTinyGo, or Golang
+	SubscriberFnName string       // overrides generated accessor func name (default: <StructName>Topic)
+	ComponentFnName  string       // overrides generated mount component func name (default: Add<StructName>Topic)
 }
 
 // CreateTopic declares a topic. The CLI AST scanner detects this call and


### PR DESCRIPTION
# v2.17.2 - Automated WASM Optimization & Topic Compiler Control

This release focuses on making the WASM toolchain truly "zero-setup" by automating the installation of **Binaryen (`wasm-opt`)** and providing granular control over topic manager compilation. We've also refined the WASM cache to be more surgical, preventing unrelated topic changes from invalidating your entire project.

## Highlights

- **Automated Binaryen Installation**: Gothic now automatically downloads and caches `wasm-opt` for your platform (including Apple Silicon). TinyGo and Binaryen download **in parallel** on a fresh install.
- **Topic Compiler Choice**: `TopicConfig` now supports the `Compiler` field (`GothicTinyGo`, `LocalTinyGo`, `Golang`).
- **Resilient WASM Pipeline**: Build no longer crashes if `wasm-opt` is missing; it falls back to unoptimized builds with a clear warning.
- **Surgical WASM Cache**: Refined invalidation logic so only pages with actual code dependencies on a changed topic are rebuilt.
- **Improved DX**: Warnings for missing tools are now batch-aware, appearing once per build/reload cycle.

---

## Zero-Setup WASM Optimization

TinyGo relies on `wasm-opt` to produce small, production-ready binaries. Previously, users had to install the Binaryen toolkit manually. Gothic now handles this automatically:

- **Detection**: Checks system `PATH` first, then the managed cache directory.
- **Auto-Download**: Fetches the correct Binaryen v117 binary for `linux`, `darwin` (Intel & Apple Silicon), and `windows`.
- **Parallel Install**: On a fresh machine with neither TinyGo nor Binaryen present, both toolchains are downloaded concurrently — no waiting for one to finish before the other starts.
- **All Compiler Paths Covered**: The managed Binaryen binary is used by all three compiler choices (`GothicTinyGo`, `LocalTinyGo`, `Golang`). Previously `LocalTinyGo` only checked the system `PATH` and would incorrectly skip optimization even after Binaryen was auto-downloaded.
- **Graceful Fallback**: If the tool cannot be found or downloaded, the CLI sets `WASMOPT=false` to allow the build to proceed unoptimized rather than failing.

### New Warning System
When optimization is skipped, Gothic emits a batch-aware warning (once per build cycle):
`WASM wasm-opt not found; skipping optimization (WASMOPT=false). Install Binaryen for smaller binaries.`

---

## Topic Compiler Control

You can now choose the compiler toolchain for each topic manager individually. This is useful if your topic logic requires the full Go standard library (using `Golang`) or a specific local TinyGo version.

```go
var _ = CreateTopic(Page{}, TopicConfig{
    Name:        "page",
    Compression: BROTLI,
    Compiler:    Golang, // GothicTinyGo (default), LocalTinyGo, or Golang
})
```

| Compiler | Backend | Use Case |
|----------|---------|----------|
| `GothicTinyGo` | Managed TinyGo | **Default.** Smallest binaries, zero setup. |
| `LocalTinyGo` | System `tinygo` | Use a specific version installed on your machine. |
| `Golang` | Standard `go` | Full `encoding/json`, `net/http` support. Larger binaries. |

---

## Surgical Cache Invalidation

We've refined the cache invalidation logic to prevent unnecessary rebuilds:

- **Topic-Specific Hashes**: Topic manager caches are now unique to their `Name`, `Compiler`, and `Compression`. Changing one topic no longer invalidates unrelated topic managers.
- **Import-Based Page Invalidation**: Pages only rebuild when their actual imported code dependencies change. A page that does not import a changed topic package will not be rebuilt. Pages that do import it are correctly invalidated via the existing dependency scanner.
- **Compiler Sensitivity**: The WASM cache now correctly detects changes in the requested compiler, ensuring binaries are updated when switching between TinyGo and Golang.

---

## What Changed

### TopicConfig Updates
The `TopicConfig` struct (and its runtime/stub counterparts) has a new field:
```go
type TopicConfig struct {
    Name             string
    Compression      Compression
    Compiler         WasmCompiler // New: GothicTinyGo (default), LocalTinyGo, or Golang
    SubscriberFnName string
    ComponentFnName  string
}
```

### New Internal Helpers
| File | Purpose |
|------|---------|
| `pkg/helpers/wasm/wasm_binary.go` | Added `EnsureBinaryen`, `EnvironWithWarn`, `BinaryenBinary`, `BinaryenRoot`; parallel TinyGo+Binaryen download via errgroup; separate mutexes per toolchain |
| `pkg/helpers/wasm/wasm_build.go` | `wasm-opt` resolution now checks managed Binaryen for all compiler paths; `warnOnce` threaded through build pipeline; `buildCommandForCompiler` covers topic managers |
| `pkg/helpers/wasm/wasm_cache.go` | Refined `pageInputHash` (import-based invalidation) and `topicManagerInputHash` (per-topic hashing by name, compiler, compression) |
| `pkg/helpers/wasm/wasm_log.go` | Added `wasmWarnf` for batch-aware warnings |
