### PR TITLE
feat(wasm): add CreateWasmFuncWithReturn for value-returning JS callbacks

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var CURRENT_VERSION string = "v2.17.3"
+var CURRENT_VERSION string = "v2.17.4"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/pkg/wasm/stubs.go
+++ b/pkg/wasm/stubs.go
@@ -204,6 +204,22 @@ func CreateWasmFunc(name string, fn func())            {}
 func CreateWasmStringFunc(name string, fn func(string)) {}
 func CreateWasmBoolFunc(name string, fn func(bool))    {}
 
+// CreateWasmFuncWithReturn registers a named global JS function that can return a value back to JS.
+// Wraps syscall/js.FuncOf. Use when a JS library expects a callback that returns a value
+// synchronously (e.g. option objects, formatters, renderers). The function persists for the
+// lifetime of the page. Returns a JSValue so it can be passed directly to JS object properties.
+//
+// Example:
+//
+//	// Register a callback and pass it as a property on a JS config object:
+//	cb := CreateWasmFuncWithReturn("myCallback", func(this JSValue, args []JSValue) any {
+//	    return args[0].String() + "_suffix"
+//	})
+//	config.Set("formatter", cb)
+func CreateWasmFuncWithReturn(name string, fn func(this JSValue, args []JSValue) any) JSValue {
+	return JSValue{}
+}
+
 // ── Topic infrastructure (generated code only — not part of the user API) ────
 
 // TopicKey is a typed key used by the auto-generated topic system.

--- a/pkg/wasm/wasm-runtime/runtime/events.go
+++ b/pkg/wasm/wasm-runtime/runtime/events.go
@@ -205,3 +205,21 @@ func CreateWasmBoolFunc(name string, fn func(bool)) {
 		})
 	})
 }
+
+// CreateWasmFuncWithReturn registers a named global JS function that can return a value back to JS.
+// Wraps syscall/js.FuncOf. The returned JSValue holds the js.Func so it can be passed
+// directly to JS object properties (chart configs, map renderers, etc.) that require a
+// synchronous return value. The js.Func is retained in keep and never released — it must
+// stay alive for the lifetime of the page; releasing it would panic on the next invocation.
+func CreateWasmFuncWithReturn(name string, fn func(this JSValue, args []JSValue) any) JSValue {
+	f := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		jsArgs := make([]JSValue, len(args))
+		for i, a := range args {
+			jsArgs[i] = JSValue{a}
+		}
+		return toJSVal(fn(JSValue{this}, jsArgs))
+	})
+	keep = append(keep, f)
+	js.Global().Set(name, f)
+	return JSValue{f.Value}
+}

--- a/pkg/wasm/wasm-runtime/runtime/events_stub.go
+++ b/pkg/wasm/wasm-runtime/runtime/events_stub.go
@@ -5,3 +5,5 @@ package runtime
 func CreateWasmFunc(name string, fn func())            {}
 func CreateWasmStringFunc(name string, fn func(string)) {}
 func CreateWasmBoolFunc(name string, fn func(bool))    {}
+
+func CreateWasmFuncWithReturn(name string, fn func(this JSValue, args []JSValue) any) JSValue { return JSValue{} }


### PR DESCRIPTION
## What's new

### `CreateWasmFuncWithReturn` — Value-Returning JS Callback Constructor

Gothic WASM code can now hand a **value-returning** Go closure to JavaScript without
dropping down to `ExecJS`. `CreateWasmFuncWithReturn` wraps `syscall/js.FuncOf`, registers the
closure as a named global, and returns a `JSValue` holding the underlying `js.Func`
so it can be assigned directly to a JS object property.

This closes the last gap in the Go→JS callback family. Until now we had:

- `CreateWasmFunc` / `CreateWasmStringFunc` / `CreateWasmBoolFunc` — fire-and-forget
  callbacks invoked from HTML attributes, all returning `void`.

Third-party JS libraries (uPlot, Chart.js, Leaflet, ECharts, …) routinely accept
**option callbacks that must return a value synchronously** — axis tick formatters,
tooltip renderers, point-style resolvers. Those could not be expressed with the
void-returning helpers, forcing an `ExecJS` string-eval workaround that lost type
safety and Go-side state. `CreateWasmFuncWithReturn` makes them first-class.

The `js.Func` is retained for the lifetime of the page (added to the runtime `keep`
slice and never released), matching the persistence semantics of the existing
`AddEventListener*` and `CreateWasm*` helpers — so it is safe to install once during
`ClientSideState` setup.

#### Signature

```go
func CreateWasmFuncWithReturn(name string, fn func(this JSValue, args []JSValue) any) JSValue
```

The returned `any` is marshalled back to JS via the same conversion used by
`JSValue.Set`/`Call`, so returning a `JSValue`, a string, a number, or a bool all work
as expected.

#### Example

```go
import . "github.com/felipegenef/gothicframework/v2/pkg/wasm"

func ClientSideState() {
    // Register a callback and pass it as a property on a JS library config object.
    cb := CreateWasmFuncWithReturn("myFormatter", func(this JSValue, args []JSValue) any {
        return args[0].String() + "_suffix"
    })

    config := JS().Get("Object").New()
    config.Set("formatter", cb) // JS calls this and reads the return value
}
```

## Bug fixes / improvements
None.
